### PR TITLE
Add -L$(MPI_HOME)/lib64 to NVLDFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ endif
 
 ifeq ($(MPI), 1)
 NVCUFLAGS += -DMPI_SUPPORT -I$(MPI_HOME)/include
-NVLDFLAGS += -L$(MPI_HOME)/lib -lmpi
+NVLDFLAGS += -L$(MPI_HOME)/lib -L$(MPI_HOME)/lib64 -lmpi
 endif
 LIBRARIES += curand nccl nvToolsExt
 NVLDFLAGS += $(LIBRARIES:%=-l%)


### PR DESCRIPTION
In some cases, the MPI library is not in $(MPI_HOME)/lib but
in $(MPI_HOME)/lib64. For example, on RedHat like Linux system
(CentOS, Amazon Linux), and MPI is installed by yum or rpm.

Under such circumstance, the current make file will cause failure.
This patch address this issue by adding -L$(MPI_HOME)/lib64 to
NVLDFLAGS in src/Makefile.

Signed-off-by: Wei Zhang <wzam@amazon.com>