### PR TITLE
Fix bandwidth reporting in all-to-all benchmark

### DIFF
--- a/src/alltoall.cu
+++ b/src/alltoall.cu
@@ -51,7 +51,7 @@ testResult_t AlltoAllInitData(struct threadArgs* args, ncclDataType_t type, nccl
 }
 
 void AlltoAllGetBw(size_t count, int typesize, double sec, double* algBw, double* busBw, int nranks) {
-  double baseBw = (double)(count * nranks * typesize) / 1.0E9 / sec;
+  double baseBw = (double)(count * nranks * nranks * typesize) / 1.0E9 / sec;
 
   *algBw = baseBw;
   double factor = ((double)(nranks-1))/((double)(nranks));


### PR DESCRIPTION
Each of `nranks` source GPUs sends `count * typesize` bytes to each of `nranks` target GPUs, i.e. the total amount of data transmitted is `count * nranks * nranks * typesize` bytes.