### PR TITLE
Add boot_id to the hostname hash due to collisions on Azure

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -164,13 +164,44 @@ static void getHostName(char* hostname, int maxlen) {
 
 #include <stdint.h>
 
-static uint64_t getHostHash(const char* string) {
+static uint64_t getHash(const char* string, size_t n) {
   // Based on DJB2a, result = result * 33 ^ char
   uint64_t result = 5381;
-  for (int c = 0; string[c] != '\0'; c++){
+  for (size_t c = 0; c < n; c++) {
     result = ((result << 5) + result) ^ string[c];
   }
   return result;
+}
+
+/* Generate a hash of the unique identifying string for this host
+ * that will be unique for both bare-metal and container instances
+ * Equivalent of a hash of;
+ *
+ * $(hostname)$(cat /proc/sys/kernel/random/boot_id)
+ *
+ */
+#define HOSTID_FILE "/proc/sys/kernel/random/boot_id"
+static uint64_t getHostHash(const char* hostname) {
+  char hostHash[1024];
+
+  // Fall back is the hostname if something fails
+  (void) strncpy(hostHash, hostname, sizeof(hostHash));
+  int offset = strlen(hostHash);
+
+  FILE *file = fopen(HOSTID_FILE, "r");
+  if (file != NULL) {
+    char *p;
+    if (fscanf(file, "%ms", &p) == 1) {
+        strncpy(hostHash+offset, p, sizeof(hostHash)-offset-1);
+        free(p);
+    }
+  }
+  fclose(file);
+
+  // Make sure the string is terminated
+  hostHash[sizeof(hostHash)-1]='\0';
+
+  return getHash(hostHash, strlen(hostHash));
 }
 
 static size_t wordSize(ncclDataType_t type) {


### PR DESCRIPTION
Adds "/proc/sys/kernel/random/boot_id" to the hostname hash

Fixes #60