### PR TITLE
Add option to statically link cudart

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,7 @@ DEBUG ?= 0
 CUDA_LIB ?= $(CUDA_HOME)/lib64
 CUDA_INC ?= $(CUDA_HOME)/include
 NVCC = $(CUDA_HOME)/bin/nvcc
+CUDARTLIB ?= cudart
 
 CUDA_VERSION = $(strip $(shell which $(NVCC) >/dev/null && $(NVCC) --version | grep release | sed 's/.*release //' | sed 's/\,.*//'))
 CUDA_MAJOR = $(shell echo $(CUDA_VERSION) | cut -d "." -f 1)
@@ -36,7 +37,7 @@ endif
 NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++11
 
 LDFLAGS    := -L${CUDA_LIB} -lcudart -lrt
-NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt
+NVLDFLAGS  := -L${CUDA_LIB} -l${CUDARTLIB} -lrt
 
 ifeq ($(DEBUG), 0)
 NVCUFLAGS += -O3 -g
@@ -68,7 +69,7 @@ ifeq ($(MPI_IBM),1)
 NVCUFLAGS += -DMPI_SUPPORT
 NVLDFLAGS += -lmpi_ibm
 endif
-LIBRARIES += curand nccl nvToolsExt
+LIBRARIES += nccl
 NVLDFLAGS += $(LIBRARIES:%=-l%)
 
 DST_DIR := $(BUILDDIR)

--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <cstdint>
 #include <algorithm>
-#include <curand.h>
 #ifdef MPI_SUPPORT
 #include "mpi.h"
 #endif
@@ -46,7 +45,6 @@ typedef enum {
   testInternalError = 1,
   testCudaError = 2,
   testNcclError = 3,
-  testCuRandError = 4
 } testResult_t;
 
 // Relay errors up and trace


### PR DESCRIPTION
Build with `CUDARTLIB=cudart_static` to remove dynamic linkage

Also removed unused curand and nvToolsExt dependencies

BUG 95