### PR TITLE
Support setting CUDA_VISIBLE_DEVICES env variable

### DIFF
--- a/src/all_gather.cu
+++ b/src/all_gather.cu
@@ -19,10 +19,12 @@ testResult_t AllGatherInitData(struct threadArgs* args, ncclDataType_t type, ncc
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? ((char*)args->recvbuffs[i])+rank*args->sendBytes : args->sendbuffs[i];

--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -19,10 +19,12 @@ testResult_t AllReduceInitData(struct threadArgs* args, ncclDataType_t type, ncc
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/alltoall.cu
+++ b/src/alltoall.cu
@@ -19,11 +19,13 @@ testResult_t AlltoAllInitData(struct threadArgs* args, ncclDataType_t type, nccl
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     char* str = getenv("NCCL_TESTS_DEVICE");
     int gpuid = str ? atoi(str) : args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/broadcast.cu
+++ b/src/broadcast.cu
@@ -18,10 +18,12 @@ void BroadcastGetCollByteCount(size_t *sendcount, size_t *recvcount, size_t *par
 testResult_t BroadcastInitData(struct threadArgs* args, ncclDataType_t type, ncclRedOp_t op, int root, int rep, int in_place) {
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/gather.cu
+++ b/src/gather.cu
@@ -19,10 +19,12 @@ testResult_t GatherInitData(struct threadArgs* args, ncclDataType_t type, ncclRe
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? ((char*)args->recvbuffs[i])+rank*args->sendBytes : args->sendbuffs[i];

--- a/src/hypercube.cu
+++ b/src/hypercube.cu
@@ -22,10 +22,12 @@ testResult_t HyperCubeInitData(struct threadArgs* args, ncclDataType_t type, ncc
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? ((char*)args->recvbuffs[i])+rank*args->sendBytes : args->sendbuffs[i];

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -19,10 +19,12 @@ testResult_t ReduceInitData(struct threadArgs* args, ncclDataType_t type, ncclRe
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/reduce_scatter.cu
+++ b/src/reduce_scatter.cu
@@ -19,10 +19,12 @@ testResult_t ReduceScatterInitData(struct threadArgs* args, ncclDataType_t type,
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/scatter.cu
+++ b/src/scatter.cu
@@ -18,10 +18,12 @@ void ScatterGetCollByteCount(size_t *sendcount, size_t *recvcount, size_t *param
 testResult_t ScatterInitData(struct threadArgs* args, ncclDataType_t type, ncclRedOp_t op, int root, int rep, int in_place) {
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];

--- a/src/sendrecv.cu
+++ b/src/sendrecv.cu
@@ -19,10 +19,12 @@ testResult_t SendRecvInitData(struct threadArgs* args, ncclDataType_t type, nccl
   size_t sendcount = args->sendBytes / wordSize(type);
   size_t recvcount = args->expectedBytes / wordSize(type);
   int nranks = args->nProcs*args->nThreads*args->nGpus;
+  int nGpusVisible;
+  CUDACHECK(cudaGetDeviceCount(&nGpusVisible));
 
   for (int i=0; i<args->nGpus; i++) {
     int gpuid = args->localRank*args->nThreads*args->nGpus + args->thread*args->nGpus + i;
-    CUDACHECK(cudaSetDevice(gpuid));
+    CUDACHECK(cudaSetDevice(gpuid % nGpusVisible));
     int rank = ((args->proc*args->nThreads + args->thread)*args->nGpus + i);
     CUDACHECK(cudaMemset(args->recvbuffs[i], 0, args->expectedBytes));
     void* data = in_place ? args->recvbuffs[i] : args->sendbuffs[i];


### PR DESCRIPTION
I'm resubmitting this, as an update to #105

I attempted to validate the patch in light of the comments on that PR.  Please let me know if I'm misunderstanding.

To evaluate this comment:
"For example, if you run with 2 ranks, and set CUDA_VISIBLE_DEVICES to "0,1,2,3" on one rank and "4,5,6,7" and the other rank, then launch with only 2 GPUs per rank, users would expect to use 0,1 and 4,5 but instead we'd use 0,1 and 6,7."

I applied the proposed patch and added logging (zerodev) to show the offset of the actual device from zero.  I launched with two nodes, one process per node, and two GPUs per process, which results in two 2 GPUs per rank.

```
ubuntu@ip-172-31-30-49:~$ ./dompi
ip-172-31-21-32 CUDA_VISIBLE_DEVICES=4,5,6,7
ip-172-31-30-49 CUDA_VISIBLE_DEVICES=0,1,2,3
# nThread 1 nGpus 2 minBytes 8 maxBytes 8 step: 2(factor) warmup iters: 5 iters: 100 validation: 1
#
# Using devices
#   Rank  0 Pid  36533 on ip-172-31-30-49 device  0 [0x00] devid=0x16 zerodev=0 domid=0x0 Tesla V100-SXM2-32GB
#   Rank  1 Pid  36533 on ip-172-31-30-49 device  1 [0x00] devid=0x17 zerodev=1 domid=0x0 Tesla V100-SXM2-32GB
#   Rank  2 Pid  33645 on ip-172-31-21-32 device  0 [0x00] devid=0x1a zerodev=4 domid=0x0 Tesla V100-SXM2-32GB
#   Rank  3 Pid  33645 on ip-172-31-21-32 device  1 [0x00] devid=0x1b zerodev=5 domid=0x0 Tesla V100-SXM2-32GB
#
#                                                       out-of-place                       in-place
#       size         count      type   redop     time   algbw   busbw  error     time   algbw   busbw  error
#        (B)    (elements)                       (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
           8             2     float     sum    163.9    0.00    0.00  1e-07    163.3    0.00    0.00  0e+00
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 7.33647e-05
```

To evaluate this comment:
"Also, today if you run on a 4 GPUs system and launch 8 ranks or one rank with -g 8 it will error out as "invalid CUDA numeral" or something similar. With this patch it would try to re-use each GPU twice (and generate and error later during NCCL init)."

When I run the patch with four devices but a GPUs requested, I get an argument error.

```
ubuntu@ip-172-31-30-49:~$ CUDA_VISIBLE_DEVICES=7,6,5,4 nccl-tests/build/all_reduce_perf -b 8 -e 8 -f 2 -g 8 -c 1 -n 100
invalid number of GPUs specified (8), only for 4 GPUs exist
```
