### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ To build the tests, just type `make`.
 If CUDA is not installed in /usr/local/cuda, you may specify CUDA\_HOME. Similarly, if NCCL is not installed in /usr, you may specify NCCL\_HOME.
 
 ```shell
-$ make CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
+$ CXXFLAGS="-std=c++11" make CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
 ```
 
 NCCL tests rely on MPI to work on multiple processes, hence multiple nodes. If you want to compile the tests with MPI support, you need to set MPI=1 and set MPI\_HOME to the path where MPI is installed.
 
 ```shell
-$ make MPI=1 MPI_HOME=/path/to/mpi CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
+$ CXXFLAGS="-std=c++11" make MPI=1 MPI_HOME=/path/to/mpi CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
 ```
 
 ## Usage


### PR DESCRIPTION
Adding CFLAG for new build dependency

Recently tried to build nccl-tests and ran into the following error. Adding the CFLAG for c++11 resolved the build issue.

`[opc@compute-permanent-node-306 nccl-tests]$ sudo make MPI=1 MPI_HOME=<mpi-home> CUDA_HOME=<cuda-home> NCCL_HOME=<nccl-home>
make -C src build BUILDDIR=/home/opc/nccl-tests/build
make[1]: Entering directory `/home/opc/nccl-tests/src'
Compiling  timer.cc                            > /home/opc/nccl-tests/build/timer.o
In file included from /usr/include/c++/4.8.2/cstdint:35:0,
                 from timer.h:4,
                 from timer.cc:1:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
In file included from timer.cc:1:0:
timer.h:8:3: error: ‘uint64_t’ in namespace ‘std’ does not name a type
   std::uint64_t t0;
   ^
timer.cc:8:3: error: ‘uint64_t’ in namespace ‘std’ does not name a type
   std::uint64_t now() {
   ^
timer.cc: In constructor ‘timer::timer()’:
timer.cc:15:3: error: ‘t0’ was not declared in this scope
   t0 = now();
   ^
timer.cc:15:12: error: ‘now’ was not declared in this scope
   t0 = now();
            ^
timer.cc: In member function ‘double timer::elapsed() const’:
timer.cc:19:3: error: ‘uint64_t’ is not a member of ‘std’
   std::uint64_t t1 = now();
   ^
timer.cc:19:17: error: expected ‘;’ before ‘t1’
   std::uint64_t t1 = now();
                 ^
timer.cc:20:17: error: ‘t1’ was not declared in this scope
   return 1.e-9*(t1 - t0);
                 ^
timer.cc:20:22: error: ‘t0’ was not declared in this scope
   return 1.e-9*(t1 - t0);
                      ^
timer.cc: In member function ‘double timer::reset()’:
timer.cc:24:3: error: ‘uint64_t’ is not a member of ‘std’
   std::uint64_t t1 = now();
   ^
timer.cc:24:17: error: expected ‘;’ before ‘t1’
   std::uint64_t t1 = now();
                 ^
timer.cc:25:23: error: ‘t1’ was not declared in this scope
   double ans = 1.e-9*(t1 - t0);
                       ^
timer.cc:25:28: error: ‘t0’ was not declared in this scope
   double ans = 1.e-9*(t1 - t0);
                            ^
make[1]: *** [/home/opc/nccl-tests/build/timer.o] Error 1
make[1]: Leaving directory `/home/opc/nccl-tests/src'
make: *** [src.build] Error 2`