### PR TITLE
Don't call MPI_Comm_split if NCCL_TESTS_SPLIT_MASK is not set

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -860,13 +860,18 @@ testResult_t run() {
     if (hostHashs[p] == hostHashs[proc]) localRank++;
   }
 
+  MPI_Comm mpi_comm = MPI_COMM_WORLD;
   char* str = getenv("NCCL_TESTS_SPLIT_MASK");
-  uint64_t mask = str ? strtoul(str, NULL, 16) : 0;
-  MPI_Comm mpi_comm;
-  color = proc & mask;
-  MPI_Comm_split(MPI_COMM_WORLD, color, proc, &mpi_comm);
-  MPI_Comm_size(mpi_comm, &ncclProcs);
-  MPI_Comm_rank(mpi_comm, &ncclProc);
+  if (str) {
+    uint64_t mask = strtoul(str, NULL, 16);
+    color = proc & mask;
+    MPI_Comm_split(MPI_COMM_WORLD, color, proc, &mpi_comm);
+    MPI_Comm_size(mpi_comm, &ncclProcs);
+    MPI_Comm_rank(mpi_comm, &ncclProc);
+  } else {
+    ncclProcs = totalProcs;
+    ncclProc = proc;
+  }
 #endif
   is_main_thread = is_main_proc = (proc == 0) ? 1 : 0;
 


### PR DESCRIPTION
No need to call MPI_Comm_split if the NCCL_TESTS_SPLIT_MASK variable is not set.
It only causes unnecessary traffic with no real effect, and in some cases might cause the ranks be invalid.