### PR TITLE
clarify that the measurement is unidirectional

### DIFF
--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance reported by NCCL tests
 
-NCCL tests report the average operation time in ms, and two bandwidths in GB/s : algorithm bandwidth and bus bandwidth. This page explains what those numbers mean and what you should expect depending on the hardware used.
+NCCL tests report the average operation time in ms, and two bandwidths in GB/s : algorithm bandwidth and bus bandwidth. The measurement is of a unidirectional bandwidth. This page explains what those numbers mean and what you should expect depending on the hardware used.
 
 # Time
 


### PR DESCRIPTION
This PR adds a clarification that the measurement is done against a unidirectional bandwidth and not duplex.

Otherwise it's not clear to the user whether they should compare the outcome to the unidirectional or duplex advertised performance of the network.

So when I run nccl-tests on intra-node A100 with NVLink 3, I get best throughput around 235GBps - which is out of 300GBps advertised unidirectional peak performance and not 600GBps duplex. ~80% checks out, but 40% doesn't.

Thank you.