### PR TITLE
improve parsing of stepbytes (increment size) argument

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -764,7 +764,12 @@ int main(int argc, char* argv[]) {
         maxBytes = (size_t)parsed;
         break;
       case 'i':
-        stepBytes = strtol(optarg, NULL, 0);
+        parsed = parsesize(optarg);
+        if (parsed < 0) {
+          fprintf(stderr, "invalid size specified for 'stepBytes'\n");
+          return -1;
+        }
+        stepBytes = (size_t)parsed;
         break;
       case 'f':
         stepFactor = strtol(optarg, NULL, 0);


### PR DESCRIPTION
fixes issue #225 stepbytes (increment size) argument does not support 1M notation

if you run this command
.build/all_reduce_perf -b 64M -e 70M -i 2M -g 1

the increment is not parsed as 2M but as 2 bytes, which is quite unexpected 