### PR TITLE
fix: nvls all reduce correction factor

### DIFF
--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -136,6 +136,7 @@ And :
 To obtain a bus bandwidth which should be independent of the number of ranks _n_, we apply a correction factor to the algorithm bandwidth :
 
 * AllReduce : 2*(_n_-1)/_n_
+* AllReduce (In-Network Reduction): (n-1)/(n+1)
 * ReduceScatter : (_n_-1)/_n_
 * AllGather : (_n_-1)/_n_
 * Broadcast : 1

--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -36,7 +36,16 @@ void AllReduceGetBw(size_t count, int typesize, double sec, double* algBw, doubl
   double baseBw = (double)(count * typesize) / 1.0E9 / sec;
 
   *algBw = baseBw;
-  double factor = ((double)(2*(nranks - 1)))/((double)nranks);
+
+  const char* nccl_algo = getenv("NCCL_ALGO");
+
+  double factor;
+  if (nccl_algo != nullptr && (strcmp(nccl_algo, "NVLS") == 0 || strcmp(nccl_algo, "NVLSTREE") == 0)) {
+    factor = ((double)(nranks - 1)) / ((double)(nranks + 1));
+  } else {
+    factor = ((double)(2 * (nranks - 1))) / ((double)nranks);
+  }
+
   *busBw = baseBw * factor;
 }
 


### PR DESCRIPTION
I was running single server H100 (8xH100 SXM) `nccl-tests` and saw that the Bus BW `480Gbyte/s` even tho the line rate is `450Gbyte/s`

According to https://github.com/NVIDIA/nccl-tests/issues/212#issuecomment-2210390757 , The acutal correction factor should be `bus_bw = algo_bw * (n-1)/(n+1)` instead of `bus_bw = algo_bw * 2(n-1)/n`

This PR is probably not mergable since `NCCL_ALGO` can be auto picked or be contained in `/etc/nccl.conf` and there doesn't seem to have an API for seeing what algo `nccl` has chose. Correction factors for `CollnetDirect` and `CollnetChain` on the IB Network probably needs to be updated too.

But just wanted to put it here in case anyone else in the community is confused.

## Before
![image](https://github.com/user-attachments/assets/3f710b92-dbdd-4e87-9078-b84a22d0fe31)

## After
![image](https://github.com/user-attachments/assets/a091a0de-aadb-4d99-aea0-30dc231fa353)

## Factor vs number of ranks
![image](https://github.com/user-attachments/assets/5b9dc1d1-c1e8-4c32-8da3-cf6eb1842f7b)

