### PR TITLE
Print the name of the program being executed

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "cuda.h"
+#include <errno.h>     /* program_invocation_short_name */
 
 #include "../verifiable/verifiable.h"
 
@@ -1006,6 +1007,7 @@ testResult_t run() {
 #endif
   is_main_thread = is_main_proc = (proc == 0) ? 1 : 0;
 
+  PRINT("# Collective test starting: %s\n", program_invocation_short_name);
   PRINT("# nThread %d nGpus %d minBytes %ld maxBytes %ld step: %ld(%s) warmup iters: %d iters: %d agg iters: %d validation: %d graph: %d\n",
         nThreads, nGpus, minBytes, maxBytes,
         (stepFactor > 1)?stepFactor:stepBytes, (stepFactor > 1)?"factor":"bytes",
@@ -1257,6 +1259,7 @@ testResult_t run() {
   PRINT("# Out of bounds values : %d %s\n", errors[0], errors[0] ? "FAILED" : "OK");
   PRINT("# Avg bus bandwidth    : %g %s\n", bw[0], check_avg_bw == -1 ? "" : (bw[0] < check_avg_bw*(0.9) ? "FAILED" : "OK"));
   PRINT("#\n");
+  PRINT("# Collective test concluded: %s\n", program_invocation_short_name);
 #ifdef MPI_SUPPORT
   MPI_Comm_free(&mpi_comm);
   MPI_Finalize();


### PR DESCRIPTION
One thing missing from the stdout of each performance test is the name of the test that is actually being run.

This patch adds 2 new messages to the stdout. At the beginning of the execution of a test (e.g. sendrecv_perf) we will now see this message:
```
# Collective test starting: sendrecv_perf
```
And at the end, we will now see this:
```
# Collective test concluded: sendrecv_perf
```

This is needed when running several tests consecutively and we're trying to parse the stdout to collect the results.

For example, using a Python script to parse the stdout, one could retrieve the results for each test and plot them on a graph. This patch makes it easier to implement such a script.

_**NOTE**: In the long run it would be nice to have an option to change the output format. For example, if there was a `--json` option to print the result as a JSON object, then parsing with Python would be a breeze. But this would require some drastic refactoring of the code. Therefore, this simple patch is probably best for now._ 