### PR TITLE
Fix Clang compilation errors with VLA initialization

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -1344,8 +1344,10 @@ testResult_t run() {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)
   ncclDevComm devComms[nThreads*nGpus];
 #endif
-  int64_t initGpuMem[nThreads] = {0};
-  int64_t bufferMemory[nThreads] = {0};
+  int64_t initGpuMem[nThreads];
+  int64_t bufferMemory[nThreads];
+  memset(initGpuMem, 0, sizeof(initGpuMem));
+  memset(bufferMemory, 0, sizeof(bufferMemory));
   if (!parallel_init) {
     // Capture the memory used by the GPUs before initializing the NCCL communicators
     int64_t* initFreeGpuMem = (int64_t*)calloc(nGpus*3, sizeof(int64_t));


### PR DESCRIPTION
Code failed to compile with Clang on following:

```
common.cu(1347): error: variable "initGpuMem" may not be initialized
    int64_t initGpuMem[nThreads] = {0};
            ^
common.cu(1348): error: variable "bufferMemory" may not be initialized
    int64_t bufferMemory[nThreads] = {0};
            ^
2 errors detected in the compilation of "common.cu".
```