### PR TITLE
Fix SIGABRT in JSON (-J) output on error/early-return paths

### DIFF
--- a/src/util.cu
+++ b/src/util.cu
@@ -362,14 +362,25 @@ void jsonIdentifyWriter(bool is_writer) {
 void jsonOutputFinalize() {
   if(write_json) {
 
-    jsonKey("end_time");
-    char timebuffer[128];
-    formatNow(timebuffer, sizeof(timebuffer));
-    jsonStr(timebuffer);
+    // An early/error return from run() can leave nested objects/lists open
+    // on the state stack. Only append end_time when the root object is still
+    // the current container, then close whatever remains open so we always
+    // emit valid JSON instead of aborting on an assert.
+    if(state_n == 1 && (jsonCurrState() == JSON_OBJECT_EMPTY || jsonCurrState() == JSON_OBJECT_SOME)) {
+      jsonKey("end_time");
+      char timebuffer[128];
+      formatNow(timebuffer, sizeof(timebuffer));
+      jsonStr(timebuffer);
+    }
 
-    jsonFinishObject();
+    while(state_n > 0) {
+      switch(jsonCurrState()) {
+        case JSON_LIST_EMPTY: case JSON_LIST_SOME:     jsonFinishList();   break;
+        case JSON_OBJECT_EMPTY: case JSON_OBJECT_SOME: jsonFinishObject(); break;
+        default:                                       jsonPopState();     break;
+      }
+    }
 
-    assert(jsonCurrState() == JSON_NONE);
     free(states);
     states = nullptr;
     state_n = 0;


### PR DESCRIPTION
## Summary
When JSON output (`-J`) is enabled, `jsonOutputFinalize()` aborts the process with `SIGABRT` if a run returns early through an error path, instead of exiting cleanly. This turns any failed run into a crash whenever `-J` is set.

## Root cause
The JSON writer keeps a global state stack of open objects/lists and relies on every `jsonStart*` being matched by a `jsonFinish*`. `jsonOutputFinalize()` — called unconditionally from `main()` after `run()` returns — ends with:
```c
jsonFinishObject();
assert(jsonCurrState() == JSON_NONE);
```
Several error paths in `run()` return before the matching `jsonFinish*` calls execute — e.g. the *"Invalid number of GPUs"* check in `writeDeviceReport()` returns while the `"config"` object is still open, and a failed collective during the benchmark returns while the `"results"` list (and a result object) is open. The leftover open container leaves the stack non-empty at finalize, so the assert fails and the process aborts.

## Reproduction (4-GPU host)
```
# without -J: clean error exit
$ ./all_reduce_perf -b 8 -e 8 -g 99 ; echo $?
... Invalid number of GPUs: 99 requested but only 4 were found.
5

# with -J: SIGABRT
$ ./all_reduce_perf -b 8 -e 8 -g 99 -J out.json ; echo $?
... Invalid number of GPUs: 99 requested but only 4 were found.
all_reduce_perf: util.cu:372: void jsonOutputFinalize(): Assertion `jsonCurrState() == JSON_NONE' failed.
134
```

## Fix
Make `jsonOutputFinalize()` tolerant of an unbalanced stack: append `end_time` only when the root object is still the current container, then drain the stack — closing any open lists/objects — so a partial run always writes valid (truncated) JSON and never aborts.

## Testing
Built `MPI=0` and run on a multi-GPU host:
- Error path (`-g 99 -J`): now exits cleanly (code 5, matching the no-`-J` behavior) with valid truncated JSON. *(was SIGABRT / code 134)*
- Happy path (`-g 1 -b 8 -e 4M -J`): unchanged — exits 0 with complete, valid JSON.
