### PR TITLE
Adding an `MPI_INCLUDE` check in the `src/Makefile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ NCCL tests rely on MPI to work on multiple processes, hence multiple nodes. If y
 $ make MPI=1 MPI_HOME=/path/to/mpi CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
 ```
 
+In some distributions, MPI's header files may not reside in `$MPI_HOME/include`. In this case, you can set `MPI_INCLUDE` to the path where MPI's header files are installed. 
+
+```shell
+$ make MPI=1 MPI_HOME=/path/to/mpi MPI_INCLUDE=/path/to/mpi/headers CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
+```
+
 You can also add a suffix to the name of the generated binaries with `NAME_SUFFIX`. For example when compiling with the MPI versions you could use:
 
 ```shell

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,8 @@ NVLDFLAGS += -L$(NCCL_HOME)/lib
 endif
 
 ifeq ($(MPI), 1)
-NVCUFLAGS += -DMPI_SUPPORT -I$(MPI_HOME)/include
+MPI_INCLUDE ?= $(MPI_HOME)/include
+NVCUFLAGS += -DMPI_SUPPORT -I$(MPI_INCLUDE)
 NVLDFLAGS += -L$(MPI_HOME)/lib -L$(MPI_HOME)/lib64 -lmpi
 endif
 ifeq ($(MPI_IBM),1)


### PR DESCRIPTION
Addresses #391.

In some distributions, OpenMPI's header files might not be installed in `$MPI_HOME/include`. Adding an `MPI_INCLUDE` check so that `make` passes the correct include path to `nvcc`.