### PR TITLE
Replace unused cuRAND include with the standard math header

### DIFF
--- a/src/comm_ops.cu
+++ b/src/comm_ops.cu
@@ -22,7 +22,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <time.h>
-#include <curand.h>
+#include <math.h>
 #include <stdint.h>
 #include <getopt.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #395.

Replace the unused cuRAND include with math.h, which directly declares the pow, sqrt, and roundf functions used by the benchmark.

## Validation

- Original include failure reproduced with curand.h deliberately forbidden.
- Non-MPI and MPI-enabled host compilation passed using real CUDA 12.9, NCCL 2.31.2, and OpenMPI headers.
- Non-MPI diagnostic and exit status preserved.
- git diff --check passed.

Validation: https://github.com/sylvesterkaczmarek/SkillSpector/actions/runs/34509461728

NVCC, the NVIDIA HPC SDK, and GPU benchmark execution were not tested.